### PR TITLE
Refactor sprite loading so it loads all tex into buffers

### DIFF
--- a/Renderer.cpp
+++ b/Renderer.cpp
@@ -57,8 +57,8 @@ int Renderer::init() {
 
 
     // init other OpenGL stuff
-    float projectionWidth = 10;
-    float projectionHeight = 10;
+    float projectionWidth = 4;
+    float projectionHeight = 4;
     float CENTER_X_COORD = 0;
     float CENTER_Y_COORD = 0;
     float LEFT_X_COORD = CENTER_X_COORD - projectionWidth / 2;
@@ -80,7 +80,6 @@ int Renderer::init() {
 	// except we use refs
 	glGenBuffers(1, &vertexBuffer); // gen == generate
     glGenBuffers(1, &indicesBuffer);
-    glGenTextures(1, &textureBuffer);
 	glGenVertexArrays(1, &vertexAttribs);
 
     // tell opengl the size of the viewport (window)
@@ -102,8 +101,8 @@ void Renderer::loadImages() {
     // read config data
     struct ImgConfig {
         const char* name;
-        int row;
-        int column;
+        int rows;
+        int columns;
     };
     ImgConfig configs[]{
         {
@@ -131,19 +130,46 @@ void Renderer::loadImages() {
 
     for (ImgConfig config : configs) {
         // read the image from the file and store it
-        SpriteInfo* info = FileManager::readImageFile(config.name);
-        if (info == NULL) {
-            std::cout << "Failed to load texture" << std::endl;
+        SpriteInfo info;
+        int colChannels;
+        stbi_uc* imgData = FileManager::readImageFile(config.name, &info.width, &info.height, &colChannels);
+        if (!imgData) {
+            std::cout << "Failed to load texture: " << config.name << std::endl;
             return;
         }
 
-        info->row = config.row;
-        info->column = config.column;
-        sprites[config.name] = *info;
+        // create the texture buffer and store its id in info
+        info.id = createTexBuffer(info, imgData);
+        info.rows = config.rows;
+        info.columns = config.columns;
 
-        // delete the data if needed
-        //stbi_image_free(data); 
+        // store the new sprite
+        sprites[config.name] = info;
+
+        // delete the data
+        stbi_image_free(imgData); 
     }
+}
+
+GLuint Renderer::createTexBuffer(SpriteInfo info, stbi_uc* imgData) {
+    // create a texture buffer
+    GLuint id;
+    glGenTextures(1, &id);
+
+    // bind the texture (tell OpenGL that it's the cur tex)
+    //note* needs to be above any texture functions so that it is applied to the binded texture
+    glBindTexture(GL_TEXTURE_2D, id);
+
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, info.width, info.height, 0, GL_RGBA, GL_UNSIGNED_BYTE, imgData);
+    glGenerateMipmap(GL_TEXTURE_2D);
+
+    // set the texture wrapping/filtering options (on the currently bound texture object)
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+
+    return id;
 }
 
 GLFWwindow* Renderer::setupGLFW(int *width, int *height) {
@@ -309,29 +335,16 @@ void Renderer::loadIndicesData() {
 
 }
 
-void Renderer::loadTexture(const char *spriteName) {
-    // bind the texture (tell OpenGL that it's the cur tex)
-    //note* needs to be above any texture functions so that it is applied to the binded texture
-    glBindTexture(GL_TEXTURE_2D, textureBuffer);
-
-    const auto& result = sprites.find(spriteName);
-
+void Renderer::loadTexture(const char* spriteName) {
     // if not found
-    if (result == sprites.end()) {
+    try {
+        SpriteInfo info = sprites[spriteName];
+        glBindTexture(GL_TEXTURE_2D, info.id);
+    }
+    catch (int e) {
         std::cout << "Couldn't find image matching name: " << spriteName << std::endl;
         return;
     }
-    // take the sprite info from the sprites map
-    SpriteInfo info = sprites[spriteName];
-
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, info.width, info.height, 0, GL_RGBA, GL_UNSIGNED_BYTE, info.data);
-    glGenerateMipmap(GL_TEXTURE_2D);
-
-    // set the texture wrapping/filtering options (on the currently bound texture object)
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 }
 
 void Renderer::loadUniforms(mat4 modelMatrix) {
@@ -349,8 +362,8 @@ void Renderer::updateTexCoord(RenderComponent comp, const char* spriteName) {
     // find the height and width of each cell in the spritesheet
     const float SPRITESHEET_HEIGHT = 1;
     const float SPRITESHEET_WIDTH = 1;
-    float cellHeight = SPRITESHEET_HEIGHT / info.row;
-    float cellWidth = SPRITESHEET_WIDTH / info.column;
+    float cellHeight = SPRITESHEET_HEIGHT / info.rows;
+    float cellWidth = SPRITESHEET_WIDTH / info.columns;
 
     // coordinates of the texture coords in the vertices array
     vertices[6] = cellWidth + cellWidth * comp.colIndex; // top right x

--- a/Renderer.h
+++ b/Renderer.h
@@ -40,9 +40,6 @@ private:
     // the element buffer object (EBO) contains the vertex indices
     GLuint indicesBuffer;
 
-    // the texture contains the texture buffer
-    GLuint textureBuffer;
-
     // the default shader program
     // stored here since we most likely will use it often
     GLuint defaultShaderProgram;
@@ -58,7 +55,8 @@ private:
     GLuint createDefaultShaderProgram();
     void loadVertexData();
     void loadIndicesData();
-    void loadTexture(const char *spriteName);
+    GLuint createTexBuffer(SpriteInfo info, stbi_uc* imgData);
+    void loadTexture(const char* spriteName);
     void loadUniforms(mat4 modelMatrix);
     void loadImages();
     void updateTexCoord(RenderComponent comp, const char* spriteName);

--- a/SpriteInfo.h
+++ b/SpriteInfo.h
@@ -1,11 +1,16 @@
 #pragma once
 #include <stb/stb_image.h>
 
+// store information on a spritesheet
 struct SpriteInfo {
+    // pixel height and width
     int height;
     int width;
-    int row;
-    int column;
-    int colorChannelsAmount;
-    stbi_uc *data;
+
+    // info on the grid sizes
+    int rows;
+    int columns;
+
+    // opengl texture buffer id
+    GLuint id;
 };

--- a/file_manager.cpp
+++ b/file_manager.cpp
@@ -4,13 +4,8 @@
 #define STB_IMAGE_IMPLEMENTATION
 #include <stb/stb_image.h>
 
-SpriteInfo* FileManager::readImageFile(const char* fileName) {
-    SpriteInfo sprite;
-    sprite.data = stbi_load(fileName, &(sprite.width), &(sprite.height), &(sprite.colorChannelsAmount), STBI_rgb_alpha);
-    if (!sprite.data) {
-        return NULL;
-    }
-    return &sprite;
+stbi_uc* FileManager::readImageFile(const char* fileName, int* width, int* height, int* colorChannels) {
+    return stbi_load(fileName, width, height, colorChannels, STBI_rgb_alpha);
 }
 
 std::string FileManager::readTextFile(const char* fileName) {

--- a/file_manager.h
+++ b/file_manager.h
@@ -3,11 +3,12 @@
 #include <iostream>
 #include <string>
 #include <sstream>
+#include <glad/glad.h>
 #include "SpriteInfo.h"
 
 namespace FileManager
 {
-    SpriteInfo* readImageFile(const char* fileName);
+    stbi_uc* readImageFile(const char* fileName, int* width, int* height, int* colorChannels);
     std::string readTextFile(const char* fileName);
     std::string readShaderFile(const char* fileName);
 }


### PR DESCRIPTION
Before, we were storing the data of each sprite in memory and reloading them into the same buffer. Now, all textures are stored in their own buffers and we don't need to keep the data around.