### PR TITLE
Add the game over scene and text alignment

### DIFF
--- a/GameEntityCreator.cpp
+++ b/GameEntityCreator.cpp
@@ -196,13 +196,27 @@ EntityID GameEntityCreator::CreateText(std::string scoreTxt, float x, float y, f
     );
 
     // no rotation and we will use size to determine the font size, not scales.
-    ec.GetComponent<Transform>(ent) = Transform(x, y, 0, 1, 1);
+    Transform transform = Transform(x, y, 0, 1, 1);
+    transform.setInterpolatorX(Renderer::getInstance()->getTextXInterpolator());
+    transform.setInterpolatorY(Renderer::getInstance()->getTextYInterpolator());
+    ec.GetComponent<Transform>(ent) = transform;
     return ent;
 }
 
-EntityID GameEntityCreator::CreatePanel(float x, float y, float height, float width, float r, float g, float b) {
+EntityID GameEntityCreator::CreatePanel(float x, float y, float height, float width, float r, float g, float b, std::vector<Tag> tags) {
     EntityCoordinator& ec = EntityCoordinator::getInstance();
-    EntityID ent = ec.CreateEntity(uiArchetype, "", { Tag::UI });
+
+    // ensure we always have an UI tag
+    bool hasTag = false;
+    for (auto& tag : tags) {
+        if (tag == Tag::UI) {
+            hasTag = true;
+            break;
+        }
+    }
+    if (!hasTag) tags.push_back(Tag::UI);
+
+    EntityID ent = ec.CreateEntity(uiArchetype, "", tags);
 
     RenderComponent renderComp = standardRenderComponent("", false);
 

--- a/GameEntityCreator.cpp
+++ b/GameEntityCreator.cpp
@@ -182,7 +182,11 @@ EntityID GameEntityCreator::CreateTimer(const char* spriteName, std::vector<Tag>
     return ent;
 }
 
-EntityID GameEntityCreator::CreateText(std::string scoreTxt, float x, float y, float r, float g, float b, float size, std::vector<Tag> tags)
+EntityID GameEntityCreator::CreateText(std::string scoreTxt, float x, float y, float r, float g, float b, float size, std::vector<Tag> tags) {
+    return CreateText(scoreTxt, x, y, r, g, b, size, TextAlign::CENTER, tags);
+}
+
+EntityID GameEntityCreator::CreateText(std::string scoreTxt, float x, float y, float r, float g, float b, float size, TextAlign align, std::vector<Tag> tags)
 {
     EntityCoordinator& ec = EntityCoordinator::getInstance();
     EntityID ent = ec.CreateEntity(textArchetype, "Text", tags);
@@ -192,7 +196,8 @@ EntityID GameEntityCreator::CreateText(std::string scoreTxt, float x, float y, f
         size,
         r,
         g,
-        b
+        b,
+        align
     );
 
     // no rotation and we will use size to determine the font size, not scales.

--- a/GameEntityCreator.h
+++ b/GameEntityCreator.h
@@ -41,6 +41,7 @@ public:
     EntityID CreateSmallRoach(float xPos, float yPos, bool facingRight);
     EntityID CreatePlatform(float xPos, float yPos, float scaleX, float scaleY, const char* spriteName, std::vector<Tag> tags, int state);
     EntityID CreateTimer(const char* spriteName, std::vector<Tag> tags);
+    EntityID CreateText(std::string text, float x, float y, float r, float g, float b, float size, TextAlign align, std::vector<Tag> tags);
     EntityID CreateText(std::string text, float x, float y, float r, float g, float b, float size, std::vector<Tag> tags);
     EntityID CreatePanel(float x, float y, float height, float width, float r, float g, float b, std::vector<Tag> tags);
     EntityID CreateStar(float xPos, float yPos, float scaleX, float scaleY, const char* spriteName, std::vector<Tag> tags);

--- a/GameEntityCreator.h
+++ b/GameEntityCreator.h
@@ -42,7 +42,7 @@ public:
     EntityID CreatePlatform(float xPos, float yPos, float scaleX, float scaleY, const char* spriteName, std::vector<Tag> tags, int state);
     EntityID CreateTimer(const char* spriteName, std::vector<Tag> tags);
     EntityID CreateText(std::string text, float x, float y, float r, float g, float b, float size, std::vector<Tag> tags);
-    EntityID CreatePanel(float x, float y, float height, float width, float r, float g, float b);
+    EntityID CreatePanel(float x, float y, float height, float width, float r, float g, float b, std::vector<Tag> tags);
     EntityID CreateStar(float xPos, float yPos, float scaleX, float scaleY, const char* spriteName, std::vector<Tag> tags);
     EntityID CreatePhysParticle(TransformArg t, int frameLife, const char* spriteName);
 };

--- a/Interpolator.cpp
+++ b/Interpolator.cpp
@@ -9,5 +9,5 @@ void Interpolator::setInterpolation(float domainStart_, float domainEnd_, float 
 
 float Interpolator::interpolate(float value) {
     if (value > domainEnd || value < domainStart) throw std::runtime_error("Value out of range of interpolate domain.");
-    return (value - domainStart) / std::abs(domainEnd - domainStart) * (targetEnd - targetStart) + targetStart;
+    return (value - domainStart) / (domainEnd - domainStart) * (targetEnd - targetStart) + targetStart;
 }

--- a/Interpolator.h
+++ b/Interpolator.h
@@ -1,6 +1,5 @@
 #pragma once
 #include <stdexcept>
-#include <cmath>
 
 class Interpolator {
 public:

--- a/Renderer.cpp
+++ b/Renderer.cpp
@@ -518,23 +518,28 @@ void Renderer::drawText(TextComponent* text, Transform* transform)
     //need to tell opengl which sampler2d to use
     glActiveTexture(GL_TEXTURE0);
 
-    float textWidth = 0;
-    std::string textValue = text->getText();
+    float textWidth = text->getTextWidth();
+    // if textWidth hasn't been init yet
+    // find it then store it => don't have
+    // to recalculate this multiple times.
+    if (textWidth == 0) {
+        text->setTextWidth(findTextWidth(text));
+    }
 
-    std::string::const_iterator c;
-    // get the width of all characters so we can shift it 
-    // later. This will get us center aligned.
-    for (c = textValue.begin(); c != textValue.end(); c++) {
-        Character& ch = characters[*c];
-        textWidth += (ch.Advance >> 6) * text->size;
+    // this offset is used to align the text the way that we wanted
+    float offset = 0;
+    if (text->align == TextAlign::CENTER) {
+        offset = textWidth / 2;
+    }
+    else if (text->align == TextAlign::RIGHT) {
+        offset = textWidth;
     }
 
     // now draw the text.
-    // however, we will shift the x value to the left so that
-    // the middle of the text line is the origin
     float x = 0;
     float y = 0;
-    float offset = textWidth / 2;
+    std::string textValue = text->getText();
+    std::string::const_iterator c;
     for (c = textValue.begin(); c != textValue.end(); c++) {
         Character& ch = characters[*c];
 
@@ -571,6 +576,21 @@ void Renderer::drawText(TextComponent* text, Transform* transform)
 
         glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_INT, 0);
     }
+}
+
+int Renderer::findTextWidth(TextComponent* text) {
+    std::string::const_iterator c;
+    string textValue = text->getText();
+    int textWidth = 0;
+
+    // get the width of all characters so we can shift it 
+    // later. This will get us center or right aligned.
+    for (c = textValue.begin(); c != textValue.end(); c++) {
+        Character& ch = characters[*c];
+        textWidth += (ch.Advance >> 6) * text->size;
+    }
+
+    return textWidth;
 }
 
 Animation* Renderer::getAnimation(std::string animName, std::string spriteName)

--- a/Renderer.cpp
+++ b/Renderer.cpp
@@ -68,6 +68,19 @@ int Renderer::init(int viewWidth, int viewHeight, glm::vec4 newBackgroundColor, 
     camera.setViewSize(viewWidth, viewHeight);
     shaderFactory.createAllShaderPrograms();
 
+    // init the view and window size so we can
+    // setup interpolation for text
+    // note that this requires the Renderer to run its init() first
+    float startDomainX = -(viewWidth / 2);
+    float endDomainX = -startDomainX;
+    float startTargetX = -(windowWidth / 2);
+    float endTargetX = -startTargetX;
+    float startDomainY = -(viewHeight / 2);
+    float endDomainY = -startDomainY;
+    float startTargetY = -(windowHeight / 2);
+    float endTargetY = -startTargetY;
+    textPosInterpolX.setInterpolation(startDomainX, endDomainX, startTargetX, endTargetX);
+    textPosInterpolY.setInterpolation(startDomainY, endDomainY, startTargetY, endTargetY);
 
     return 0;
 }
@@ -714,6 +727,14 @@ int Renderer::getWindowWidth() {
 
 int Renderer::getWindowHeight() {
     return windowHeight;
+}
+
+Interpolator* Renderer::getTextXInterpolator() {
+    return &textPosInterpolX;
+}
+
+Interpolator* Renderer::getTextYInterpolator() {
+    return &textPosInterpolY;
 }
 
 Camera* Renderer::getCamera() {

--- a/Renderer.cpp
+++ b/Renderer.cpp
@@ -526,7 +526,7 @@ void Renderer::drawText(TextComponent* text, Transform* transform)
     // later. This will get us center aligned.
     for (c = textValue.begin(); c != textValue.end(); c++) {
         Character& ch = characters[*c];
-        textWidth += ch.size.x * text->size;
+        textWidth += (ch.Advance >> 6) * text->size;
     }
 
     // now draw the text.
@@ -538,27 +538,26 @@ void Renderer::drawText(TextComponent* text, Transform* transform)
     for (c = textValue.begin(); c != textValue.end(); c++) {
         Character& ch = characters[*c];
 
-        float xpos = x + ch.bearing.x * text->size;
+        float xpos = x + ch.bearing.x * text->size - offset;
         float ypos = y - (ch.size.y - ch.bearing.y) * text->size;
 
         float w = ch.size.x * text->size;
         float h = ch.size.y * text->size;
-        textWidth += w;
 
         // top right
-        positionsData[0] = xpos + w - offset;
+        positionsData[0] = xpos + w;
         positionsData[1] = ypos + h;
 
         // bottom right
-        positionsData[3] = xpos + w - offset;
+        positionsData[3] = xpos + w;
         positionsData[4] = ypos;
 
         // bottom left
-        positionsData[6] = xpos - offset;
+        positionsData[6] = xpos;
         positionsData[7] = ypos;
 
         // top left
-        positionsData[9] = xpos - offset;
+        positionsData[9] = xpos;
         positionsData[10] = ypos + h;
 
         //bitshift by 6 to get value in pixels (2^6 = 64)

--- a/Renderer.h
+++ b/Renderer.h
@@ -39,6 +39,8 @@ public:
     Animation* getAnimation(std::string animName, std::string spriteName);
     int getWindowWidth();
     int getWindowHeight();
+    Interpolator* getTextXInterpolator();
+    Interpolator* getTextYInterpolator();
     Camera* getCamera();
 private:
     static Renderer* renderer;
@@ -79,7 +81,10 @@ private:
     // helper classes
     ShaderFactory shaderFactory;
     Camera camera;
-
+    // for the texts' transforms
+    // since it relies on screenspace, it fits in Renderer more
+    Interpolator textPosInterpolX;
+    Interpolator textPosInterpolY;
 
     static GLFWwindow* setupGLFW(int *width, int *height, WindowSize windowSize);
 

--- a/Renderer.h
+++ b/Renderer.h
@@ -95,6 +95,7 @@ private:
     void loadImages();
     void updateTexCoord(RenderComponent comp, SpriteInfo& info);
     void drawText(TextComponent* text, Transform* transform);
+    int findTextWidth(TextComponent* text);
     void startDrawGameObjectsPhase(EntityCoordinator* coordinator);
     void startDrawUIPhase(EntityCoordinator* coordinator);
     void startDrawTextPhase(EntityCoordinator* coordinator);

--- a/SceneManager.cpp
+++ b/SceneManager.cpp
@@ -62,21 +62,6 @@ SceneManager::SceneManager() {
     renderer = Renderer::getInstance();
     this->LoadScene("scene.json");
     this->LoadPrefabs("prefab.json");
-
-    // init the view and window size so we can
-    // setup interpolation for text
-    // note that this requires the Renderer to run its init() first
-    Camera* camera = renderer->getCamera();
-    float startDomainX = -(camera->getViewWidth() / 2);
-    float endDomainX = -startDomainX;
-    float startTargetX = -(renderer->getWindowWidth() / 2);
-    float endTargetX = -startTargetX;
-    float startDomainY = -(camera->getViewHeight() / 2);
-    float endDomainY = -startDomainY;
-    float startTargetY = -(renderer->getWindowHeight() / 2);
-    float endTargetY = -startTargetY;
-    textPosInterpolX.setInterpolation(startDomainX, endDomainX, startTargetX, endTargetX);
-    textPosInterpolY.setInterpolation(startDomainY, endDomainY, startTargetY, endTargetY);
 }
 
 
@@ -136,8 +121,8 @@ void SceneManager::CreateEntities() {
             // change the transform so it uses the proper interpolation
             // only if textComponent is included
             if (ev.textComponent) {
-                transform.setInterpolatorX(&textPosInterpolX);
-                transform.setInterpolatorY(&textPosInterpolY);
+                transform.setInterpolatorX(renderer->getTextXInterpolator());
+                transform.setInterpolatorY(renderer->getTextYInterpolator());
             }
             coordinator->GetComponent<Transform>(ent) = transform;
         }

--- a/SceneManager.cpp
+++ b/SceneManager.cpp
@@ -56,6 +56,12 @@ unordered_map <std::string, const char*> spriteMap = {
     {"fire.png", "fire.png"}
 };
 
+unordered_map <std::string, TextAlign> textAlignMap = {
+    {"left", TextAlign::LEFT},
+    {"center", TextAlign::CENTER},
+    {"right", TextAlign::RIGHT}
+};
+
 
 SceneManager::SceneManager() {
     coordinator = &(EntityCoordinator::getInstance());
@@ -178,7 +184,7 @@ void SceneManager::CreateEntities() {
                 ev.colorR,
                 ev.colorG,
                 ev.colorB,
-                TextAlign::CENTER
+                ev.align
             );
         }
     }
@@ -302,6 +308,9 @@ void SceneManager::ParseEntityValues(EntityValues& ev, const json& jsonObject) {
 
                 ev.size = details.contains("size")
                     ? details["size"].get<float>() : ev.size;
+
+                ev.align = details.contains("align")
+                    ? textAlignMap[details["align"].get<std::string>()] : ev.align;
 
                 break;
             }

--- a/SceneManager.cpp
+++ b/SceneManager.cpp
@@ -177,7 +177,8 @@ void SceneManager::CreateEntities() {
                 ev.size,
                 ev.colorR,
                 ev.colorG,
-                ev.colorB
+                ev.colorB,
+                TextAlign::CENTER
             );
         }
     }

--- a/SceneManager.h
+++ b/SceneManager.h
@@ -66,15 +66,7 @@ private:
     json prefabJsonArray;
     unordered_map<std::string, json> prefabMap;
 
-    // for the texts
-    Interpolator textPosInterpolX;
-    Interpolator textPosInterpolY;
-
-
     void ParseEntityValues(EntityValues& ev, const json& jsonObject);
-
-
-
 public:
     
     SceneManager();

--- a/SceneManager.h
+++ b/SceneManager.h
@@ -54,6 +54,8 @@ struct EntityValues {
     // share the colors with the RenderComponent
     std::string text = "";
     float size = 1.0;
+    // specify the alignment of the text
+    TextAlign align = TextAlign::CENTER;
 };
 
 // Scene Manager class

--- a/Tags.h
+++ b/Tags.h
@@ -17,5 +17,6 @@ enum Tag
     ENEMYSPAWNER,
     PLAYERSPAWNER,
     TXT_SCORE,
-    HEALTH_NUM
+    HEALTH_NUM,
+    GAME_OVER_UI
 };

--- a/TextComponent.cpp
+++ b/TextComponent.cpp
@@ -3,12 +3,14 @@
 // init static
 std::vector<std::string> TextComponent::texts;
 
-TextComponent::TextComponent(std::string text, float size, float r, float g, float b) : size(size) {
+TextComponent::TextComponent(std::string text, float size, float r, float g, float b, TextAlign align_=TextAlign::CENTER) : size(size) {
     texts.push_back(text);
     textID = texts.size() - 1; // get the last index.
     color.r = r;
     color.g = g;
     color.b = b;
+    align = align_;
+    textWidth = 0;
 }
 
 void TextComponent::clearTexts() {
@@ -21,4 +23,13 @@ void TextComponent::setText(std::string text) {
 
 std::string TextComponent::getText() {
     return texts[textID];
+}
+
+void TextComponent::setTextWidth(float width) {
+    if (width < 0) return;
+    textWidth = width;
+}
+
+float TextComponent::getTextWidth() {
+    return textWidth;
 }

--- a/TextComponent.h
+++ b/TextComponent.h
@@ -3,6 +3,12 @@
 #include <glm/glm.hpp>
 #pragma once
 
+enum class TextAlign {
+    LEFT,
+    CENTER,
+    RIGHT
+};
+
 class TextComponent
 {
 public:
@@ -17,14 +23,23 @@ public:
     float size; //scale of the text
     glm::vec3 color;
 
-    TextComponent(std::string text, float size, float r, float g, float b);
+    TextAlign align;
+
+    TextComponent(std::string text, float size, float r, float g, float b, TextAlign align_);
 
     // set the color of the text. It must be in the range of [0, 1].
     void setColor(float r, float g, float b) { color.r = r; color.g = g; color.b = b; }
 
     void setText(std::string text);
     std::string getText();
+
+    void setTextWidth(float width);
+    float getTextWidth();
 private:
     // the index of the text in the static texts variable.
     int textID; 
+
+    // the width of the text on the screen
+    // is only set after drawn one time on the screen
+    float textWidth;
 };

--- a/main.cpp
+++ b/main.cpp
@@ -118,18 +118,21 @@ void identifyPlayerAndPlayerSpawner()
 /// <param name="scores">The scores that were gotten.</param>
 void createGameOverOverlay(int playerScore, vector<string> dates, vector<string> scores) {
     auto& creator = GameEntityCreator::getInstance();
-    int yPos = 5; // use this so we can change the starting yPos easily
+    float viewHeight = Renderer::getInstance()->getCamera()->getViewHeight();
+    float viewWidth = Renderer::getInstance()->getCamera()->getViewWidth();
+    float yPos = viewHeight / 2 - 2; // use this so we can change the starting yPos easily
 
     // create the panel
-    creator.CreatePanel(0, 0, 6, 6, 0, 0, 0, {Tag::GAME_OVER_UI});
+    // fill 80% of the screen
+    creator.CreatePanel(0, 0, viewHeight * 0.8, viewWidth * 0.6, 0, 0, 0, {Tag::GAME_OVER_UI});
 
     // create the title and user score
-    creator.CreateText("GAME OVER", 0, 5, 1, 1, 1, 1.5, { Tag::GAME_OVER_UI });
+    creator.CreateText("GAME OVER", 0, yPos, 1, 0, 0, 1.5, { Tag::GAME_OVER_UI });
+    yPos -= 0.5;
+    creator.CreateText("SCORE: " + to_string(playerScore), 0, yPos, 1, 0, 0, 1, { Tag::GAME_OVER_UI });
     yPos -= 1;
-    creator.CreateText("SCORE: " + to_string(playerScore), 0, yPos, 1, 1, 1, 1, { Tag::GAME_OVER_UI });
-    yPos -= 1.5;
 
-    creator.CreateText("SCORE: " + to_string(playerScore), 0, yPos, 1, 1, 1, 1, { Tag::GAME_OVER_UI });
+    creator.CreateText("HIGHSCORES", 0, yPos, 1, 1, 1, 1, { Tag::GAME_OVER_UI });
     yPos -= 1;
     int highscoresCount = 5;
     for (int i = 0; i < highscoresCount; i++) {
@@ -149,13 +152,13 @@ void createGameOverOverlay(int playerScore, vector<string> dates, vector<string>
             score = "0";
         }
 
-        creator.CreateText(date, -2, yPos, 1, 1, 1, 1, { Tag::GAME_OVER_UI });
-        creator.CreateText(score, 2, yPos, 1, 1, 1, 1, { Tag::GAME_OVER_UI });
-        yPos--;
+        creator.CreateText(date, -1, yPos, 1, 1, 1, 1, { Tag::GAME_OVER_UI });
+        creator.CreateText(score, 3, yPos, 1, 1, 1, 1, { Tag::GAME_OVER_UI });
+        yPos -= 0.75;
     }
 
     // replay instruction
-    creator.CreateText("Press J to replay, Q to quit", 2, yPos, 1, 1, 1, 1, {Tag::GAME_OVER_UI});
+    creator.CreateText("J to replay. Q to quit", 0, yPos, 1, 0, 0, 1, {Tag::GAME_OVER_UI});
 }
 
 void removeGameOverOverlay() {
@@ -208,10 +211,10 @@ int initialize()
 
     vector<string> scores = {
         "15",
+        "5",
         "15",
         "15",
-        "15",
-        "15",
+        "5",
     };
     createGameOverOverlay(10, dates, scores);
 

--- a/main.cpp
+++ b/main.cpp
@@ -110,6 +110,58 @@ void identifyPlayerAndPlayerSpawner()
     }
 }
 
+/// <summary>
+/// Create the game over overlay on top of the current scene.
+/// Note that we are only displaying the top 5 highest scores.
+/// </summary>
+/// <param name="dates">The dates the scores were gotten.</param>
+/// <param name="scores">The scores that were gotten.</param>
+void createGameOverOverlay(int playerScore, vector<string> dates, vector<string> scores) {
+    auto& creator = GameEntityCreator::getInstance();
+    int yPos = 5; // use this so we can change the starting yPos easily
+
+    // create the panel
+    creator.CreatePanel(0, 0, 6, 6, 0, 0, 0, {Tag::GAME_OVER_UI});
+
+    // create the title and user score
+    creator.CreateText("GAME OVER", 0, 5, 1, 1, 1, 1.5, { Tag::GAME_OVER_UI });
+    yPos -= 1;
+    creator.CreateText("SCORE: " + to_string(playerScore), 0, yPos, 1, 1, 1, 1, { Tag::GAME_OVER_UI });
+    yPos -= 1.5;
+
+    creator.CreateText("SCORE: " + to_string(playerScore), 0, yPos, 1, 1, 1, 1, { Tag::GAME_OVER_UI });
+    yPos -= 1;
+    int highscoresCount = 5;
+    for (int i = 0; i < highscoresCount; i++) {
+        string date;
+        try {
+            date = dates.at(i);
+        }
+        catch (out_of_range) {
+            date = "-----";
+        }
+
+        string score;
+        try {
+            score = scores.at(i);
+        }
+        catch (out_of_range) {
+            score = "0";
+        }
+
+        creator.CreateText(date, -2, yPos, 1, 1, 1, 1, { Tag::GAME_OVER_UI });
+        creator.CreateText(score, 2, yPos, 1, 1, 1, 1, { Tag::GAME_OVER_UI });
+        yPos--;
+    }
+
+    // replay instruction
+    creator.CreateText("Press J to replay, Q to quit", 2, yPos, 1, 1, 1, 1, {Tag::GAME_OVER_UI});
+}
+
+void removeGameOverOverlay() {
+
+}
+
 // gets called once when engine starts
 // put initilization code here
 int initialize()
@@ -145,6 +197,23 @@ int initialize()
     se.loadMusic(music);
 
     prevTime = Clock::now();
+
+    vector<string> dates = {
+        "2020/11/30 11:30",
+        "2020/11/30 11:30",
+        "2020/11/30 11:30",
+        "2020/11/30 11:30",
+        "2020/11/30 11:30",
+    };
+
+    vector<string> scores = {
+        "15",
+        "15",
+        "15",
+        "15",
+        "15",
+    };
+    createGameOverOverlay(10, dates, scores);
 
     return 0;
 }

--- a/main.cpp
+++ b/main.cpp
@@ -163,7 +163,14 @@ void createGameOverOverlay(int playerScore, vector<string> dates, vector<string>
 }
 
 void removeGameOverOverlay() {
+    std::shared_ptr<EntityQuery> query = coordinator->GetEntityQuery(
+        { }, { Tag::GAME_OVER_UI });
 
+
+    int uiFound = query->totalEntitiesFound();
+    for (int i = 0; i < uiFound; i++) {
+
+    }
 }
 
 // gets called once when engine starts
@@ -202,22 +209,23 @@ int initialize()
 
     prevTime = Clock::now();
 
-    vector<string> dates = {
-        "2020/11/30 11:30",
-        "2020/11/30 11:30",
-        "2020/11/30 11:30",
-        "2020/11/30 11:30",
-        "2020/11/30 11:30",
-    };
+    // code to make the game over overlay
+    //vector<string> dates = {
+    //    "2020/11/30 11:30",
+    //    "2020/11/30 11:30",
+    //    "2020/11/30 11:30",
+    //    "2020/11/30 11:30",
+    //    "2020/11/30 11:30",
+    //};
 
-    vector<string> scores = {
-        "15",
-        "5",
-        "15",
-        "15",
-        "5",
-    };
-    createGameOverOverlay(10, dates, scores);
+    //vector<string> scores = {
+    //    "15",
+    //    "5",
+    //    "15",
+    //    "15",
+    //    "5",
+    //};
+    //createGameOverOverlay(10, dates, scores);
 
     return 0;
 }

--- a/main.cpp
+++ b/main.cpp
@@ -152,12 +152,13 @@ void createGameOverOverlay(int playerScore, vector<string> dates, vector<string>
             score = "0";
         }
 
-        creator.CreateText(date, -1, yPos, 1, 1, 1, 1, { Tag::GAME_OVER_UI });
-        creator.CreateText(score, 3, yPos, 1, 1, 1, 1, { Tag::GAME_OVER_UI });
+        creator.CreateText(date, -3, yPos, 1, 1, 1, 1, TextAlign::LEFT, { Tag::GAME_OVER_UI });
+        creator.CreateText(score, 3, yPos, 1, 1, 1, 1, TextAlign::RIGHT, { Tag::GAME_OVER_UI });
         yPos -= 0.75;
     }
 
     // replay instruction
+    yPos -= 0.5;
     creator.CreateText("J to replay. Q to quit", 0, yPos, 1, 0, 0, 1, {Tag::GAME_OVER_UI});
 }
 

--- a/scene.json
+++ b/scene.json
@@ -1,1 +1,1536 @@
-[{"tag":"player","transform":{"xScale":1,"yScale":1,"yPos":1},"render":{"sprite":"Edgar.png","hasAnim":true},"physics":{"b2bodytype":"b2_dynamicBody","density":1,"friction":0},"animation":{"animName":"idle","isPlaying":true},"state":{}},{"tag":"ui","transform":{"xScale":0.5,"yScale":0.5,"xPos":-6,"yPos":4.25},"render":{"sprite":"Edgar.png","rowIndex":0,"colIndex":0}},{"tag":"healthNum","text":{"text":"X 3"},"transform":{"xPos":-5.5,"yPos":4}},{"tag":"scoreText","text":{"text":"00000"},"transform":{"xPos":4.5,"yPos":4}},{"usePrefab":"WallRight","transform":{"xPos":-6.75,"yPos":4.25}},{"usePrefab":"WallRight","transform":{"xPos":-6.75,"yPos":3.75}},{"usePrefab":"WallRight","transform":{"xPos":-6.75,"yPos":3.25}},{"usePrefab":"WallRight","transform":{"xPos":-6.75,"yPos":2.75}},{"usePrefab":"WallRight","transform":{"xPos":-6.75,"yPos":2.25}},{"usePrefab":"WallRight","transform":{"xPos":-6.75,"yPos":1.75}},{"usePrefab":"WallRight","transform":{"xPos":-6.75,"yPos":1.25}},{"usePrefab":"Platform","transform":{"xPos":-6.75,"yPos":0.75}},{"usePrefab":"Collider","tag":"wall","transform":{"xPos":-6.75,"yPos":2.5,"xScale":0.5,"yScale":4}},{"usePrefab":"WallRight","transform":{"xPos":-6.75,"yPos":0.25}},{"usePrefab":"WallRight","transform":{"xPos":-6.75,"yPos":-0.25}},{"usePrefab":"WallRight","transform":{"xPos":-6.75,"yPos":-0.75}},{"usePrefab":"WallRight","transform":{"xPos":-6.75,"yPos":-1.25}},{"usePrefab":"WallRight","transform":{"xPos":-6.75,"yPos":-1.75}},{"usePrefab":"WallRight","transform":{"xPos":-6.75,"yPos":-2.25}},{"usePrefab":"WallRight","transform":{"xPos":-6.75,"yPos":-2.75}},{"usePrefab":"Collider","tag":"wall","transform":{"xPos":-6.75,"yPos":-1.25,"xScale":0.5,"yScale":3.5}},{"usePrefab":"WallLeft","transform":{"xPos":6.75,"yPos":4.25}},{"usePrefab":"WallLeft","transform":{"xPos":6.75,"yPos":3.75}},{"usePrefab":"WallLeft","transform":{"xPos":6.75,"yPos":3.25}},{"usePrefab":"WallLeft","transform":{"xPos":6.75,"yPos":2.75}},{"usePrefab":"WallLeft","transform":{"xPos":6.75,"yPos":2.25}},{"usePrefab":"WallLeft","transform":{"xPos":6.75,"yPos":1.75}},{"usePrefab":"WallLeft","transform":{"xPos":6.75,"yPos":1.25}},{"usePrefab":"Platform","transform":{"xPos":6.75,"yPos":0.75}},{"usePrefab":"Collider","tag":"wall","transform":{"xPos":6.75,"yPos":2.5,"xScale":0.5,"yScale":4}},{"usePrefab":"WallLeft","transform":{"xPos":6.75,"yPos":0.25}},{"usePrefab":"WallLeft","transform":{"xPos":6.75,"yPos":-0.25}},{"usePrefab":"WallLeft","transform":{"xPos":6.75,"yPos":-0.75}},{"usePrefab":"WallLeft","transform":{"xPos":6.75,"yPos":-1.25}},{"usePrefab":"WallLeft","transform":{"xPos":6.75,"yPos":-1.75}},{"usePrefab":"WallLeft","transform":{"xPos":6.75,"yPos":-2.25}},{"usePrefab":"WallLeft","transform":{"xPos":6.75,"yPos":-2.75}},{"usePrefab":"Collider","tag":"wall","transform":{"xPos":6.75,"yPos":-1.25,"xScale":0.5,"yScale":3.5}},{"usePrefab":"Platform","transform":{"xPos":-6.75,"yPos":4.75}},{"usePrefab":"Ceiling","transform":{"xPos":-6.25,"yPos":4.75}},{"usePrefab":"Ceiling","transform":{"xPos":-5.75,"yPos":4.75}},{"usePrefab":"Ceiling","transform":{"xPos":-5.25,"yPos":4.75}},{"usePrefab":"Ceiling","transform":{"xPos":-4.75,"yPos":4.75}},{"usePrefab":"Ceiling","transform":{"xPos":-4.25,"yPos":4.75}},{"usePrefab":"Ceiling","transform":{"xPos":-3.75,"yPos":4.75}},{"usePrefab":"Ceiling","transform":{"xPos":-3.25,"yPos":4.75}},{"usePrefab":"Ceiling","transform":{"xPos":-2.75,"yPos":4.75}},{"usePrefab":"Ceiling","transform":{"xPos":-2.25,"yPos":4.75}},{"usePrefab":"Ceiling","transform":{"xPos":-1.75,"yPos":4.75}},{"usePrefab":"Wa","transform":{"xPos":-1.25,"yPos":4.75}},{"usePrefab":"Collider","tag":"platform","transform":{"xPos":-4,"yPos":4.75,"xScale":6,"yScale":0.5}},{"usePrefab":"Platform","transform":{"xPos":6.75,"yPos":4.75}},{"usePrefab":"Ceiling","transform":{"xPos":6.25,"yPos":4.75}},{"usePrefab":"Ceiling","transform":{"xPos":5.75,"yPos":4.75}},{"usePrefab":"Ceiling","transform":{"xPos":5.25,"yPos":4.75}},{"usePrefab":"Ceiling","transform":{"xPos":4.75,"yPos":4.75}},{"usePrefab":"Ceiling","transform":{"xPos":4.25,"yPos":4.75}},{"usePrefab":"Ceiling","transform":{"xPos":3.75,"yPos":4.75}},{"usePrefab":"Ceiling","transform":{"xPos":3.25,"yPos":4.75}},{"usePrefab":"Ceiling","transform":{"xPos":2.75,"yPos":4.75}},{"usePrefab":"Ceiling","transform":{"xPos":2.25,"yPos":4.75}},{"usePrefab":"Ceiling","transform":{"xPos":1.75,"yPos":4.75}},{"usePrefab":"Ceiling","transform":{"xPos":1.25,"yPos":4.75}},{"usePrefab":"Collider","tag":"platform","transform":{"xPos":4,"yPos":4.75,"xScale":6,"yScale":0.5}},{"usePrefab":"Collider","_comment":"block the top left ceiling","tag":"platform","transform":{"xPos":-1.25,"yPos":5.25,"xScale":0.5,"yScale":0.5}},{"usePrefab":"Collider","_comment":"block the top left ceiling","tag":"platform","transform":{"xPos":-1.25,"yPos":5.75,"xScale":0.5,"yScale":0.5}},{"usePrefab":"Collider","_comment":"block the top left ceiling","tag":"platform","transform":{"xPos":1.25,"yPos":5.25,"xScale":0.5,"yScale":0.5}},{"usePrefab":"Collider","_comment":"block the top left ceiling","tag":"platform","transform":{"xPos":1.25,"yPos":5.75,"xScale":0.5,"yScale":0.5}},{"usePrefab":"PlatformLeftCorner","transform":{"xPos":-1.75,"yPos":2.75}},{"usePrefab":"PlatformMiddle","transform":{"xPos":-1.25,"yPos":2.75}},{"usePrefab":"PlatformMiddle","transform":{"xPos":-0.75,"yPos":2.75}},{"usePrefab":"PlatformMiddle","transform":{"xPos":-0.25,"yPos":2.75}},{"usePrefab":"PlatformMiddle","transform":{"xPos":0.25,"yPos":2.75}},{"usePrefab":"PlatformMiddle","transform":{"xPos":0.75,"yPos":2.75}},{"usePrefab":"PlatformMiddle","transform":{"xPos":1.25,"yPos":2.75}},{"usePrefab":"PlatformRightCorner","transform":{"xPos":1.75,"yPos":2.75}},{"usePrefab":"Collider","tag":"platform","transform":{"xPos":0,"yPos":2.75,"xScale":4,"yScale":0.5}},{"usePrefab":"PlatformMiddle","transform":{"xPos":-6.25,"yPos":0.75}},{"usePrefab":"PlatformMiddle","transform":{"xPos":-5.75,"yPos":0.75}},{"usePrefab":"PlatformMiddle","transform":{"xPos":-5.25,"yPos":0.75}},{"usePrefab":"PlatformMiddle","transform":{"xPos":-4.75,"yPos":0.75}},{"usePrefab":"PlatformMiddle","transform":{"xPos":-4.25,"yPos":0.75}},{"usePrefab":"PlatformMiddle","transform":{"xPos":-3.75,"yPos":0.75}},{"usePrefab":"PlatformRightCorner","transform":{"xPos":-3.25,"yPos":0.75}},{"usePrefab":"Collider","tag":"platform","transform":{"xPos":-4.75,"yPos":0.75,"xScale":3.5,"yScale":0.5}},{"usePrefab":"PlatformMiddle","transform":{"xPos":6.25,"yPos":0.75}},{"usePrefab":"PlatformMiddle","transform":{"xPos":5.75,"yPos":0.75}},{"usePrefab":"PlatformMiddle","transform":{"xPos":5.25,"yPos":0.75}},{"usePrefab":"PlatformMiddle","transform":{"xPos":4.75,"yPos":0.75}},{"usePrefab":"PlatformMiddle","transform":{"xPos":4.25,"yPos":0.75}},{"usePrefab":"PlatformMiddle","transform":{"xPos":3.75,"yPos":0.75}},{"usePrefab":"PlatformLeftCorner","transform":{"xPos":3.25,"yPos":0.75}},{"usePrefab":"Collider","tag":"platform","transform":{"xPos":4.75,"yPos":0.75,"xScale":3.5,"yScale":0.5}},{"usePrefab":"PlatformLeftCorner","transform":{"xPos":-2.75,"yPos":-1.25}},{"usePrefab":"PlatformMiddle","transform":{"xPos":-2.25,"yPos":-1.25}},{"usePrefab":"PlatformMiddle","transform":{"xPos":-1.75,"yPos":-1.25}},{"usePrefab":"PlatformMiddle","transform":{"xPos":-1.25,"yPos":-1.25}},{"usePrefab":"PlatformMiddle","transform":{"xPos":-0.75,"yPos":-1.25}},{"usePrefab":"PlatformMiddle","transform":{"xPos":-0.25,"yPos":-1.25}},{"usePrefab":"PlatformMiddle","transform":{"xPos":0.25,"yPos":-1.25}},{"usePrefab":"PlatformMiddle","transform":{"xPos":0.75,"yPos":-1.25}},{"usePrefab":"PlatformMiddle","transform":{"xPos":1.25,"yPos":-1.25}},{"usePrefab":"PlatformMiddle","transform":{"xPos":1.75,"yPos":-1.25}},{"usePrefab":"PlatformMiddle","transform":{"xPos":2.25,"yPos":-1.25}},{"usePrefab":"PlatformRightCorner","transform":{"xPos":2.75,"yPos":-1.25}},{"usePrefab":"Collider","tag":"platform","transform":{"xPos":0,"yPos":-1.25,"xScale":6,"yScale":0.5}},{"usePrefab":"Platform","transform":{"xPos":-6.75,"yPos":-3.25}},{"usePrefab":"PlatformMiddle","transform":{"xPos":-6.25,"yPos":-3.25}},{"usePrefab":"PlatformMiddle","transform":{"xPos":-5.75,"yPos":-3.25}},{"usePrefab":"PlatformMiddle","transform":{"xPos":-5.25,"yPos":-3.25}},{"usePrefab":"PlatformMiddle","transform":{"xPos":-4.75,"yPos":-3.25}},{"usePrefab":"PlatformRightCorner","transform":{"xPos":-4.25,"yPos":-3.25}},{"usePrefab":"Collider","tag":"platform","transform":{"xPos":-5.5,"yPos":-3.25,"xScale":3,"yScale":0.5}},{"usePrefab":"Platform","transform":{"xPos":6.75,"yPos":-3.25}},{"usePrefab":"PlatformMiddle","transform":{"xPos":6.25,"yPos":-3.25}},{"usePrefab":"PlatformMiddle","transform":{"xPos":5.75,"yPos":-3.25}},{"usePrefab":"PlatformMiddle","transform":{"xPos":5.25,"yPos":-3.25}},{"usePrefab":"PlatformMiddle","transform":{"xPos":4.75,"yPos":-3.25}},{"usePrefab":"PlatformLeftCorner","transform":{"xPos":4.25,"yPos":-3.25}},{"usePrefab":"Collider","tag":"platform","transform":{"xPos":5.5,"yPos":-3.25,"xScale":3,"yScale":0.5}},{"usePrefab":"Platform","transform":{"xPos":-6.75,"yPos":-3.75}},{"usePrefab":"Platform","transform":{"xPos":-6.25,"yPos":-3.75}},{"usePrefab":"Platform","transform":{"xPos":-5.75,"yPos":-3.75}},{"usePrefab":"Platform","transform":{"xPos":-5.25,"yPos":-3.75}},{"usePrefab":"Platform","transform":{"xPos":-4.75,"yPos":-3.75}},{"usePrefab":"WallRight","transform":{"xPos":-4.25,"yPos":-3.75}},{"usePrefab":"Collider","tag":"platform","transform":{"xPos":-5.5,"yPos":-3.75,"xScale":3,"yScale":0.5}},{"usePrefab":"Platform","transform":{"xPos":6.75,"yPos":-3.75}},{"usePrefab":"Platform","transform":{"xPos":6.25,"yPos":-3.75}},{"usePrefab":"Platform","transform":{"xPos":5.75,"yPos":-3.75}},{"usePrefab":"Platform","transform":{"xPos":5.25,"yPos":-3.75}},{"usePrefab":"Platform","transform":{"xPos":4.75,"yPos":-3.75}},{"usePrefab":"WallLeft","transform":{"xPos":4.25,"yPos":-3.75}},{"usePrefab":"Collider","tag":"platform","transform":{"xPos":5.5,"yPos":-3.75,"xScale":3,"yScale":0.5}},{"usePrefab":"Platform","transform":{"xPos":-6.75,"yPos":-4.25}},{"usePrefab":"Platform","transform":{"xPos":-6.25,"yPos":-4.25}},{"usePrefab":"Platform","transform":{"xPos":-5.75,"yPos":-4.25}},{"usePrefab":"Platform","transform":{"xPos":-5.25,"yPos":-4.25}},{"usePrefab":"Platform","transform":{"xPos":-4.75,"yPos":-4.25}},{"usePrefab":"Platform","transform":{"xPos":-4.25,"yPos":-4.25}},{"usePrefab":"Collider","tag":"platform","transform":{"xPos":-5.5,"yPos":-4.25,"xScale":3,"yScale":0.5}},{"usePrefab":"PlatformMiddle","transform":{"xPos":-3.75,"yPos":-4.25}},{"usePrefab":"PlatformMiddle","transform":{"xPos":-3.25,"yPos":-4.25}},{"usePrefab":"PlatformMiddle","transform":{"xPos":-2.75,"yPos":-4.25}},{"usePrefab":"PlatformMiddle","transform":{"xPos":-2.25,"yPos":-4.25}},{"usePrefab":"PlatformMiddle","transform":{"xPos":-1.75,"yPos":-4.25}},{"usePrefab":"PlatformRightCorner","transform":{"xPos":-1.25,"yPos":-4.25}},{"usePrefab":"Collider","tag":"platform","transform":{"xPos":-2.5,"yPos":-4.25,"xScale":3,"yScale":0.5}},{"usePrefab":"Platform","transform":{"xPos":6.75,"yPos":-4.25}},{"usePrefab":"Platform","transform":{"xPos":6.25,"yPos":-4.25}},{"usePrefab":"Platform","transform":{"xPos":5.75,"yPos":-4.25}},{"usePrefab":"Platform","transform":{"xPos":5.25,"yPos":-4.25}},{"usePrefab":"Platform","transform":{"xPos":4.75,"yPos":-4.25}},{"usePrefab":"Platform","transform":{"xPos":4.25,"yPos":-4.25}},{"usePrefab":"Collider","tag":"platform","transform":{"xPos":5.5,"yPos":-4.25,"xScale":3,"yScale":0.5}},{"usePrefab":"PlatformMiddle","transform":{"xPos":3.75,"yPos":-4.25}},{"usePrefab":"PlatformMiddle","transform":{"xPos":3.25,"yPos":-4.25}},{"usePrefab":"PlatformMiddle","transform":{"xPos":2.75,"yPos":-4.25}},{"usePrefab":"PlatformMiddle","transform":{"xPos":2.25,"yPos":-4.25}},{"usePrefab":"PlatformMiddle","transform":{"xPos":1.75,"yPos":-4.25}},{"usePrefab":"PlatformLeftCorner","transform":{"xPos":1.25,"yPos":-4.25}},{"usePrefab":"Collider","tag":"platform","transform":{"xPos":2.5,"yPos":-4.25,"xScale":3,"yScale":0.5}},{"usePrefab":"Platform","transform":{"xPos":-6.75,"yPos":-4.75}},{"usePrefab":"Platform","transform":{"xPos":-6.25,"yPos":-4.75}},{"usePrefab":"Platform","transform":{"xPos":-5.75,"yPos":-4.75}},{"usePrefab":"Platform","transform":{"xPos":-5.25,"yPos":-4.75}},{"usePrefab":"Platform","transform":{"xPos":-4.75,"yPos":-4.75}},{"usePrefab":"Platform","transform":{"xPos":-4.25,"yPos":-4.75}},{"usePrefab":"Platform","transform":{"xPos":-3.75,"yPos":-4.75}},{"usePrefab":"Platform","transform":{"xPos":-3.25,"yPos":-4.75}},{"usePrefab":"Platform","transform":{"xPos":-2.75,"yPos":-4.75}},{"usePrefab":"Platform","transform":{"xPos":-2.25,"yPos":-4.75}},{"usePrefab":"Platform","transform":{"xPos":-1.75,"yPos":-4.75}},{"usePrefab":"WallRight","transform":{"xPos":-1.25,"yPos":-4.75}},{"usePrefab":"Collider","tag":"platform","transform":{"xPos":-4,"yPos":-4.75,"xScale":6,"yScale":0.5}},{"usePrefab":"Platform","transform":{"xPos":6.75,"yPos":-4.75}},{"usePrefab":"Platform","transform":{"xPos":6.25,"yPos":-4.75}},{"usePrefab":"Platform","transform":{"xPos":5.75,"yPos":-4.75}},{"usePrefab":"Platform","transform":{"xPos":5.25,"yPos":-4.75}},{"usePrefab":"Platform","transform":{"xPos":4.75,"yPos":-4.75}},{"usePrefab":"Platform","transform":{"xPos":4.25,"yPos":-4.75}},{"usePrefab":"Platform","transform":{"xPos":3.75,"yPos":-4.75}},{"usePrefab":"Platform","transform":{"xPos":3.25,"yPos":-4.75}},{"usePrefab":"Platform","transform":{"xPos":2.75,"yPos":-4.75}},{"usePrefab":"Platform","transform":{"xPos":2.25,"yPos":-4.75}},{"usePrefab":"Platform","transform":{"xPos":1.75,"yPos":-4.75}},{"usePrefab":"WallLeft","transform":{"xPos":1.25,"yPos":-4.75}},{"usePrefab":"Collider","tag":"platform","transform":{"xPos":4,"yPos":-4.75,"xScale":6,"yScale":0.5}},{"usePrefab":"Fire","transform":{"xPos":-0.5}},{"usePrefab":"FireSprites","transform":{"xPos":-0.5}},{"usePrefab":"Fire","transform":{"xPos":0.5}},{"usePrefab":"FireSprites","transform":{"xPos":0.5}},{"usePrefab":"EnemySpawner","_comment":"enemy spawner top platform","transform":{"yPos":4.25}},{"usePrefab":"PlayerSpawner","_comment":"player spawner center stage","transform":{"xPos":0,"yPos":0}},{"usePrefab":"SpawnPoint","_comment":"Star Spawn Top Left","transform":{"xPos":-4.75,"yPos":1.5}},{"usePrefab":"SpawnPoint","_comment":"Star Spawn Top Right","transform":{"xPos":4.75,"yPos":1.5}},{"usePrefab":"SpawnPoint","_comment":"Star Spawn Middle Left","transform":{"xPos":-1.25,"yPos":-0.5}},{"usePrefab":"SpawnPoint","_comment":"Star Spawn Middle Right","transform":{"xPos":1.25,"yPos":-0.5}},{"usePrefab":"SpawnPoint","_comment":"Star Spawn Bottom Left","transform":{"xPos":-5.25,"yPos":-2.5}},{"usePrefab":"SpawnPoint","_comment":"Star Spawn Bottom Right","transform":{"xPos":5.25,"yPos":-2.5}},{"usePrefab":"SpawnPoint","_comment":"Star Spawn Bottom Middle Left","transform":{"xPos":-2.5,"yPos":-3.5}},{"usePrefab":"SpawnPoint","_comment":"Star Spawn Bottom Middle Right","transform":{"xPos":2.5,"yPos":-3.5}},{"usePrefab":"SpawnPoint","_comment":"Star Spawn Top Middle","transform":{"xPos":0,"yPos":3.5}}]
+[
+    {
+        "tag": "player",
+        "transform": {
+            "xScale": 1,
+            "yScale": 1,
+            "yPos": 1
+        },
+        "render": {
+            "sprite": "Edgar.png",
+            "hasAnim": true
+        },
+        "physics": {
+            "b2bodytype": "b2_dynamicBody",
+            "density": 1,
+            "friction": 0
+        },
+        "animation": {
+            "animName": "idle",
+            "isPlaying": true
+        },
+        "state": {
+        }
+    },
+    {
+        "tag": "ui",
+        "transform": {
+            "xScale": 0.5,
+            "yScale": 0.5,
+            "xPos": -6,
+            "yPos": 4.25
+        },
+        "render": {
+            "sprite": "Edgar.png",
+            "rowIndex": 0,
+            "colIndex": 0
+        }
+    },
+    {
+        "tag": "healthNum",
+        "text": {
+            "text": "X 3",
+            "align": "right"
+        },
+        "transform": {
+            "xPos": -5,
+            "yPos": 4
+        }
+    },
+    {
+        "tag": "scoreText",
+        "text": {
+            "text": "00000",
+            "align": "right"
+        },
+        "transform": {
+            "xPos": 6,
+            "yPos": 4
+        }
+    },
+    {
+        "usePrefab": "WallRight",
+        "transform": {
+            "xPos": -6.75,
+            "yPos": 4.25
+        }
+    },
+    {
+        "usePrefab": "WallRight",
+        "transform": {
+            "xPos": -6.75,
+            "yPos": 3.75
+        }
+    },
+    {
+        "usePrefab": "WallRight",
+        "transform": {
+            "xPos": -6.75,
+            "yPos": 3.25
+        }
+    },
+    {
+        "usePrefab": "WallRight",
+        "transform": {
+            "xPos": -6.75,
+            "yPos": 2.75
+        }
+    },
+    {
+        "usePrefab": "WallRight",
+        "transform": {
+            "xPos": -6.75,
+            "yPos": 2.25
+        }
+    },
+    {
+        "usePrefab": "WallRight",
+        "transform": {
+            "xPos": -6.75,
+            "yPos": 1.75
+        }
+    },
+    {
+        "usePrefab": "WallRight",
+        "transform": {
+            "xPos": -6.75,
+            "yPos": 1.25
+        }
+    },
+    {
+        "usePrefab": "Platform",
+        "transform": {
+            "xPos": -6.75,
+            "yPos": 0.75
+        }
+    },
+    {
+        "usePrefab": "Collider",
+        "tag": "wall",
+        "transform": {
+            "xPos": -6.75,
+            "yPos": 2.5,
+            "xScale": 0.5,
+            "yScale": 4
+        }
+    },
+    {
+        "usePrefab": "WallRight",
+        "transform": {
+            "xPos": -6.75,
+            "yPos": 0.25
+        }
+    },
+    {
+        "usePrefab": "WallRight",
+        "transform": {
+            "xPos": -6.75,
+            "yPos": -0.25
+        }
+    },
+    {
+        "usePrefab": "WallRight",
+        "transform": {
+            "xPos": -6.75,
+            "yPos": -0.75
+        }
+    },
+    {
+        "usePrefab": "WallRight",
+        "transform": {
+            "xPos": -6.75,
+            "yPos": -1.25
+        }
+    },
+    {
+        "usePrefab": "WallRight",
+        "transform": {
+            "xPos": -6.75,
+            "yPos": -1.75
+        }
+    },
+    {
+        "usePrefab": "WallRight",
+        "transform": {
+            "xPos": -6.75,
+            "yPos": -2.25
+        }
+    },
+    {
+        "usePrefab": "WallRight",
+        "transform": {
+            "xPos": -6.75,
+            "yPos": -2.75
+        }
+    },
+    {
+        "usePrefab": "Collider",
+        "tag": "wall",
+        "transform": {
+            "xPos": -6.75,
+            "yPos": -1.25,
+            "xScale": 0.5,
+            "yScale": 3.5
+        }
+    },
+    {
+        "usePrefab": "WallLeft",
+        "transform": {
+            "xPos": 6.75,
+            "yPos": 4.25
+        }
+    },
+    {
+        "usePrefab": "WallLeft",
+        "transform": {
+            "xPos": 6.75,
+            "yPos": 3.75
+        }
+    },
+    {
+        "usePrefab": "WallLeft",
+        "transform": {
+            "xPos": 6.75,
+            "yPos": 3.25
+        }
+    },
+    {
+        "usePrefab": "WallLeft",
+        "transform": {
+            "xPos": 6.75,
+            "yPos": 2.75
+        }
+    },
+    {
+        "usePrefab": "WallLeft",
+        "transform": {
+            "xPos": 6.75,
+            "yPos": 2.25
+        }
+    },
+    {
+        "usePrefab": "WallLeft",
+        "transform": {
+            "xPos": 6.75,
+            "yPos": 1.75
+        }
+    },
+    {
+        "usePrefab": "WallLeft",
+        "transform": {
+            "xPos": 6.75,
+            "yPos": 1.25
+        }
+    },
+    {
+        "usePrefab": "Platform",
+        "transform": {
+            "xPos": 6.75,
+            "yPos": 0.75
+        }
+    },
+    {
+        "usePrefab": "Collider",
+        "tag": "wall",
+        "transform": {
+            "xPos": 6.75,
+            "yPos": 2.5,
+            "xScale": 0.5,
+            "yScale": 4
+        }
+    },
+    {
+        "usePrefab": "WallLeft",
+        "transform": {
+            "xPos": 6.75,
+            "yPos": 0.25
+        }
+    },
+    {
+        "usePrefab": "WallLeft",
+        "transform": {
+            "xPos": 6.75,
+            "yPos": -0.25
+        }
+    },
+    {
+        "usePrefab": "WallLeft",
+        "transform": {
+            "xPos": 6.75,
+            "yPos": -0.75
+        }
+    },
+    {
+        "usePrefab": "WallLeft",
+        "transform": {
+            "xPos": 6.75,
+            "yPos": -1.25
+        }
+    },
+    {
+        "usePrefab": "WallLeft",
+        "transform": {
+            "xPos": 6.75,
+            "yPos": -1.75
+        }
+    },
+    {
+        "usePrefab": "WallLeft",
+        "transform": {
+            "xPos": 6.75,
+            "yPos": -2.25
+        }
+    },
+    {
+        "usePrefab": "WallLeft",
+        "transform": {
+            "xPos": 6.75,
+            "yPos": -2.75
+        }
+    },
+    {
+        "usePrefab": "Collider",
+        "tag": "wall",
+        "transform": {
+            "xPos": 6.75,
+            "yPos": -1.25,
+            "xScale": 0.5,
+            "yScale": 3.5
+        }
+    },
+    {
+        "usePrefab": "Platform",
+        "transform": {
+            "xPos": -6.75,
+            "yPos": 4.75
+        }
+    },
+    {
+        "usePrefab": "Ceiling",
+        "transform": {
+            "xPos": -6.25,
+            "yPos": 4.75
+        }
+    },
+    {
+        "usePrefab": "Ceiling",
+        "transform": {
+            "xPos": -5.75,
+            "yPos": 4.75
+        }
+    },
+    {
+        "usePrefab": "Ceiling",
+        "transform": {
+            "xPos": -5.25,
+            "yPos": 4.75
+        }
+    },
+    {
+        "usePrefab": "Ceiling",
+        "transform": {
+            "xPos": -4.75,
+            "yPos": 4.75
+        }
+    },
+    {
+        "usePrefab": "Ceiling",
+        "transform": {
+            "xPos": -4.25,
+            "yPos": 4.75
+        }
+    },
+    {
+        "usePrefab": "Ceiling",
+        "transform": {
+            "xPos": -3.75,
+            "yPos": 4.75
+        }
+    },
+    {
+        "usePrefab": "Ceiling",
+        "transform": {
+            "xPos": -3.25,
+            "yPos": 4.75
+        }
+    },
+    {
+        "usePrefab": "Ceiling",
+        "transform": {
+            "xPos": -2.75,
+            "yPos": 4.75
+        }
+    },
+    {
+        "usePrefab": "Ceiling",
+        "transform": {
+            "xPos": -2.25,
+            "yPos": 4.75
+        }
+    },
+    {
+        "usePrefab": "Ceiling",
+        "transform": {
+            "xPos": -1.75,
+            "yPos": 4.75
+        }
+    },
+    {
+        "usePrefab": "Wa",
+        "transform": {
+            "xPos": -1.25,
+            "yPos": 4.75
+        }
+    },
+    {
+        "usePrefab": "Collider",
+        "tag": "platform",
+        "transform": {
+            "xPos": -4,
+            "yPos": 4.75,
+            "xScale": 6,
+            "yScale": 0.5
+        }
+    },
+    {
+        "usePrefab": "Platform",
+        "transform": {
+            "xPos": 6.75,
+            "yPos": 4.75
+        }
+    },
+    {
+        "usePrefab": "Ceiling",
+        "transform": {
+            "xPos": 6.25,
+            "yPos": 4.75
+        }
+    },
+    {
+        "usePrefab": "Ceiling",
+        "transform": {
+            "xPos": 5.75,
+            "yPos": 4.75
+        }
+    },
+    {
+        "usePrefab": "Ceiling",
+        "transform": {
+            "xPos": 5.25,
+            "yPos": 4.75
+        }
+    },
+    {
+        "usePrefab": "Ceiling",
+        "transform": {
+            "xPos": 4.75,
+            "yPos": 4.75
+        }
+    },
+    {
+        "usePrefab": "Ceiling",
+        "transform": {
+            "xPos": 4.25,
+            "yPos": 4.75
+        }
+    },
+    {
+        "usePrefab": "Ceiling",
+        "transform": {
+            "xPos": 3.75,
+            "yPos": 4.75
+        }
+    },
+    {
+        "usePrefab": "Ceiling",
+        "transform": {
+            "xPos": 3.25,
+            "yPos": 4.75
+        }
+    },
+    {
+        "usePrefab": "Ceiling",
+        "transform": {
+            "xPos": 2.75,
+            "yPos": 4.75
+        }
+    },
+    {
+        "usePrefab": "Ceiling",
+        "transform": {
+            "xPos": 2.25,
+            "yPos": 4.75
+        }
+    },
+    {
+        "usePrefab": "Ceiling",
+        "transform": {
+            "xPos": 1.75,
+            "yPos": 4.75
+        }
+    },
+    {
+        "usePrefab": "Ceiling",
+        "transform": {
+            "xPos": 1.25,
+            "yPos": 4.75
+        }
+    },
+    {
+        "usePrefab": "Collider",
+        "tag": "platform",
+        "transform": {
+            "xPos": 4,
+            "yPos": 4.75,
+            "xScale": 6,
+            "yScale": 0.5
+        }
+    },
+    {
+        "usePrefab": "Collider",
+        "_comment": "block the top left ceiling",
+        "tag": "platform",
+        "transform": {
+            "xPos": -1.25,
+            "yPos": 5.25,
+            "xScale": 0.5,
+            "yScale": 0.5
+        }
+    },
+    {
+        "usePrefab": "Collider",
+        "_comment": "block the top left ceiling",
+        "tag": "platform",
+        "transform": {
+            "xPos": -1.25,
+            "yPos": 5.75,
+            "xScale": 0.5,
+            "yScale": 0.5
+        }
+    },
+    {
+        "usePrefab": "Collider",
+        "_comment": "block the top left ceiling",
+        "tag": "platform",
+        "transform": {
+            "xPos": 1.25,
+            "yPos": 5.25,
+            "xScale": 0.5,
+            "yScale": 0.5
+        }
+    },
+    {
+        "usePrefab": "Collider",
+        "_comment": "block the top left ceiling",
+        "tag": "platform",
+        "transform": {
+            "xPos": 1.25,
+            "yPos": 5.75,
+            "xScale": 0.5,
+            "yScale": 0.5
+        }
+    },
+    {
+        "usePrefab": "PlatformLeftCorner",
+        "transform": {
+            "xPos": -1.75,
+            "yPos": 2.75
+        }
+    },
+    {
+        "usePrefab": "PlatformMiddle",
+        "transform": {
+            "xPos": -1.25,
+            "yPos": 2.75
+        }
+    },
+    {
+        "usePrefab": "PlatformMiddle",
+        "transform": {
+            "xPos": -0.75,
+            "yPos": 2.75
+        }
+    },
+    {
+        "usePrefab": "PlatformMiddle",
+        "transform": {
+            "xPos": -0.25,
+            "yPos": 2.75
+        }
+    },
+    {
+        "usePrefab": "PlatformMiddle",
+        "transform": {
+            "xPos": 0.25,
+            "yPos": 2.75
+        }
+    },
+    {
+        "usePrefab": "PlatformMiddle",
+        "transform": {
+            "xPos": 0.75,
+            "yPos": 2.75
+        }
+    },
+    {
+        "usePrefab": "PlatformMiddle",
+        "transform": {
+            "xPos": 1.25,
+            "yPos": 2.75
+        }
+    },
+    {
+        "usePrefab": "PlatformRightCorner",
+        "transform": {
+            "xPos": 1.75,
+            "yPos": 2.75
+        }
+    },
+    {
+        "usePrefab": "Collider",
+        "tag": "platform",
+        "transform": {
+            "xPos": 0,
+            "yPos": 2.75,
+            "xScale": 4,
+            "yScale": 0.5
+        }
+    },
+    {
+        "usePrefab": "PlatformMiddle",
+        "transform": {
+            "xPos": -6.25,
+            "yPos": 0.75
+        }
+    },
+    {
+        "usePrefab": "PlatformMiddle",
+        "transform": {
+            "xPos": -5.75,
+            "yPos": 0.75
+        }
+    },
+    {
+        "usePrefab": "PlatformMiddle",
+        "transform": {
+            "xPos": -5.25,
+            "yPos": 0.75
+        }
+    },
+    {
+        "usePrefab": "PlatformMiddle",
+        "transform": {
+            "xPos": -4.75,
+            "yPos": 0.75
+        }
+    },
+    {
+        "usePrefab": "PlatformMiddle",
+        "transform": {
+            "xPos": -4.25,
+            "yPos": 0.75
+        }
+    },
+    {
+        "usePrefab": "PlatformMiddle",
+        "transform": {
+            "xPos": -3.75,
+            "yPos": 0.75
+        }
+    },
+    {
+        "usePrefab": "PlatformRightCorner",
+        "transform": {
+            "xPos": -3.25,
+            "yPos": 0.75
+        }
+    },
+    {
+        "usePrefab": "Collider",
+        "tag": "platform",
+        "transform": {
+            "xPos": -4.75,
+            "yPos": 0.75,
+            "xScale": 3.5,
+            "yScale": 0.5
+        }
+    },
+    {
+        "usePrefab": "PlatformMiddle",
+        "transform": {
+            "xPos": 6.25,
+            "yPos": 0.75
+        }
+    },
+    {
+        "usePrefab": "PlatformMiddle",
+        "transform": {
+            "xPos": 5.75,
+            "yPos": 0.75
+        }
+    },
+    {
+        "usePrefab": "PlatformMiddle",
+        "transform": {
+            "xPos": 5.25,
+            "yPos": 0.75
+        }
+    },
+    {
+        "usePrefab": "PlatformMiddle",
+        "transform": {
+            "xPos": 4.75,
+            "yPos": 0.75
+        }
+    },
+    {
+        "usePrefab": "PlatformMiddle",
+        "transform": {
+            "xPos": 4.25,
+            "yPos": 0.75
+        }
+    },
+    {
+        "usePrefab": "PlatformMiddle",
+        "transform": {
+            "xPos": 3.75,
+            "yPos": 0.75
+        }
+    },
+    {
+        "usePrefab": "PlatformLeftCorner",
+        "transform": {
+            "xPos": 3.25,
+            "yPos": 0.75
+        }
+    },
+    {
+        "usePrefab": "Collider",
+        "tag": "platform",
+        "transform": {
+            "xPos": 4.75,
+            "yPos": 0.75,
+            "xScale": 3.5,
+            "yScale": 0.5
+        }
+    },
+    {
+        "usePrefab": "PlatformLeftCorner",
+        "transform": {
+            "xPos": -2.75,
+            "yPos": -1.25
+        }
+    },
+    {
+        "usePrefab": "PlatformMiddle",
+        "transform": {
+            "xPos": -2.25,
+            "yPos": -1.25
+        }
+    },
+    {
+        "usePrefab": "PlatformMiddle",
+        "transform": {
+            "xPos": -1.75,
+            "yPos": -1.25
+        }
+    },
+    {
+        "usePrefab": "PlatformMiddle",
+        "transform": {
+            "xPos": -1.25,
+            "yPos": -1.25
+        }
+    },
+    {
+        "usePrefab": "PlatformMiddle",
+        "transform": {
+            "xPos": -0.75,
+            "yPos": -1.25
+        }
+    },
+    {
+        "usePrefab": "PlatformMiddle",
+        "transform": {
+            "xPos": -0.25,
+            "yPos": -1.25
+        }
+    },
+    {
+        "usePrefab": "PlatformMiddle",
+        "transform": {
+            "xPos": 0.25,
+            "yPos": -1.25
+        }
+    },
+    {
+        "usePrefab": "PlatformMiddle",
+        "transform": {
+            "xPos": 0.75,
+            "yPos": -1.25
+        }
+    },
+    {
+        "usePrefab": "PlatformMiddle",
+        "transform": {
+            "xPos": 1.25,
+            "yPos": -1.25
+        }
+    },
+    {
+        "usePrefab": "PlatformMiddle",
+        "transform": {
+            "xPos": 1.75,
+            "yPos": -1.25
+        }
+    },
+    {
+        "usePrefab": "PlatformMiddle",
+        "transform": {
+            "xPos": 2.25,
+            "yPos": -1.25
+        }
+    },
+    {
+        "usePrefab": "PlatformRightCorner",
+        "transform": {
+            "xPos": 2.75,
+            "yPos": -1.25
+        }
+    },
+    {
+        "usePrefab": "Collider",
+        "tag": "platform",
+        "transform": {
+            "xPos": 0,
+            "yPos": -1.25,
+            "xScale": 6,
+            "yScale": 0.5
+        }
+    },
+    {
+        "usePrefab": "Platform",
+        "transform": {
+            "xPos": -6.75,
+            "yPos": -3.25
+        }
+    },
+    {
+        "usePrefab": "PlatformMiddle",
+        "transform": {
+            "xPos": -6.25,
+            "yPos": -3.25
+        }
+    },
+    {
+        "usePrefab": "PlatformMiddle",
+        "transform": {
+            "xPos": -5.75,
+            "yPos": -3.25
+        }
+    },
+    {
+        "usePrefab": "PlatformMiddle",
+        "transform": {
+            "xPos": -5.25,
+            "yPos": -3.25
+        }
+    },
+    {
+        "usePrefab": "PlatformMiddle",
+        "transform": {
+            "xPos": -4.75,
+            "yPos": -3.25
+        }
+    },
+    {
+        "usePrefab": "PlatformRightCorner",
+        "transform": {
+            "xPos": -4.25,
+            "yPos": -3.25
+        }
+    },
+    {
+        "usePrefab": "Collider",
+        "tag": "platform",
+        "transform": {
+            "xPos": -5.5,
+            "yPos": -3.25,
+            "xScale": 3,
+            "yScale": 0.5
+        }
+    },
+    {
+        "usePrefab": "Platform",
+        "transform": {
+            "xPos": 6.75,
+            "yPos": -3.25
+        }
+    },
+    {
+        "usePrefab": "PlatformMiddle",
+        "transform": {
+            "xPos": 6.25,
+            "yPos": -3.25
+        }
+    },
+    {
+        "usePrefab": "PlatformMiddle",
+        "transform": {
+            "xPos": 5.75,
+            "yPos": -3.25
+        }
+    },
+    {
+        "usePrefab": "PlatformMiddle",
+        "transform": {
+            "xPos": 5.25,
+            "yPos": -3.25
+        }
+    },
+    {
+        "usePrefab": "PlatformMiddle",
+        "transform": {
+            "xPos": 4.75,
+            "yPos": -3.25
+        }
+    },
+    {
+        "usePrefab": "PlatformLeftCorner",
+        "transform": {
+            "xPos": 4.25,
+            "yPos": -3.25
+        }
+    },
+    {
+        "usePrefab": "Collider",
+        "tag": "platform",
+        "transform": {
+            "xPos": 5.5,
+            "yPos": -3.25,
+            "xScale": 3,
+            "yScale": 0.5
+        }
+    },
+    {
+        "usePrefab": "Platform",
+        "transform": {
+            "xPos": -6.75,
+            "yPos": -3.75
+        }
+    },
+    {
+        "usePrefab": "Platform",
+        "transform": {
+            "xPos": -6.25,
+            "yPos": -3.75
+        }
+    },
+    {
+        "usePrefab": "Platform",
+        "transform": {
+            "xPos": -5.75,
+            "yPos": -3.75
+        }
+    },
+    {
+        "usePrefab": "Platform",
+        "transform": {
+            "xPos": -5.25,
+            "yPos": -3.75
+        }
+    },
+    {
+        "usePrefab": "Platform",
+        "transform": {
+            "xPos": -4.75,
+            "yPos": -3.75
+        }
+    },
+    {
+        "usePrefab": "WallRight",
+        "transform": {
+            "xPos": -4.25,
+            "yPos": -3.75
+        }
+    },
+    {
+        "usePrefab": "Collider",
+        "tag": "platform",
+        "transform": {
+            "xPos": -5.5,
+            "yPos": -3.75,
+            "xScale": 3,
+            "yScale": 0.5
+        }
+    },
+    {
+        "usePrefab": "Platform",
+        "transform": {
+            "xPos": 6.75,
+            "yPos": -3.75
+        }
+    },
+    {
+        "usePrefab": "Platform",
+        "transform": {
+            "xPos": 6.25,
+            "yPos": -3.75
+        }
+    },
+    {
+        "usePrefab": "Platform",
+        "transform": {
+            "xPos": 5.75,
+            "yPos": -3.75
+        }
+    },
+    {
+        "usePrefab": "Platform",
+        "transform": {
+            "xPos": 5.25,
+            "yPos": -3.75
+        }
+    },
+    {
+        "usePrefab": "Platform",
+        "transform": {
+            "xPos": 4.75,
+            "yPos": -3.75
+        }
+    },
+    {
+        "usePrefab": "WallLeft",
+        "transform": {
+            "xPos": 4.25,
+            "yPos": -3.75
+        }
+    },
+    {
+        "usePrefab": "Collider",
+        "tag": "platform",
+        "transform": {
+            "xPos": 5.5,
+            "yPos": -3.75,
+            "xScale": 3,
+            "yScale": 0.5
+        }
+    },
+    {
+        "usePrefab": "Platform",
+        "transform": {
+            "xPos": -6.75,
+            "yPos": -4.25
+        }
+    },
+    {
+        "usePrefab": "Platform",
+        "transform": {
+            "xPos": -6.25,
+            "yPos": -4.25
+        }
+    },
+    {
+        "usePrefab": "Platform",
+        "transform": {
+            "xPos": -5.75,
+            "yPos": -4.25
+        }
+    },
+    {
+        "usePrefab": "Platform",
+        "transform": {
+            "xPos": -5.25,
+            "yPos": -4.25
+        }
+    },
+    {
+        "usePrefab": "Platform",
+        "transform": {
+            "xPos": -4.75,
+            "yPos": -4.25
+        }
+    },
+    {
+        "usePrefab": "Platform",
+        "transform": {
+            "xPos": -4.25,
+            "yPos": -4.25
+        }
+    },
+    {
+        "usePrefab": "Collider",
+        "tag": "platform",
+        "transform": {
+            "xPos": -5.5,
+            "yPos": -4.25,
+            "xScale": 3,
+            "yScale": 0.5
+        }
+    },
+    {
+        "usePrefab": "PlatformMiddle",
+        "transform": {
+            "xPos": -3.75,
+            "yPos": -4.25
+        }
+    },
+    {
+        "usePrefab": "PlatformMiddle",
+        "transform": {
+            "xPos": -3.25,
+            "yPos": -4.25
+        }
+    },
+    {
+        "usePrefab": "PlatformMiddle",
+        "transform": {
+            "xPos": -2.75,
+            "yPos": -4.25
+        }
+    },
+    {
+        "usePrefab": "PlatformMiddle",
+        "transform": {
+            "xPos": -2.25,
+            "yPos": -4.25
+        }
+    },
+    {
+        "usePrefab": "PlatformMiddle",
+        "transform": {
+            "xPos": -1.75,
+            "yPos": -4.25
+        }
+    },
+    {
+        "usePrefab": "PlatformRightCorner",
+        "transform": {
+            "xPos": -1.25,
+            "yPos": -4.25
+        }
+    },
+    {
+        "usePrefab": "Collider",
+        "tag": "platform",
+        "transform": {
+            "xPos": -2.5,
+            "yPos": -4.25,
+            "xScale": 3,
+            "yScale": 0.5
+        }
+    },
+    {
+        "usePrefab": "Platform",
+        "transform": {
+            "xPos": 6.75,
+            "yPos": -4.25
+        }
+    },
+    {
+        "usePrefab": "Platform",
+        "transform": {
+            "xPos": 6.25,
+            "yPos": -4.25
+        }
+    },
+    {
+        "usePrefab": "Platform",
+        "transform": {
+            "xPos": 5.75,
+            "yPos": -4.25
+        }
+    },
+    {
+        "usePrefab": "Platform",
+        "transform": {
+            "xPos": 5.25,
+            "yPos": -4.25
+        }
+    },
+    {
+        "usePrefab": "Platform",
+        "transform": {
+            "xPos": 4.75,
+            "yPos": -4.25
+        }
+    },
+    {
+        "usePrefab": "Platform",
+        "transform": {
+            "xPos": 4.25,
+            "yPos": -4.25
+        }
+    },
+    {
+        "usePrefab": "Collider",
+        "tag": "platform",
+        "transform": {
+            "xPos": 5.5,
+            "yPos": -4.25,
+            "xScale": 3,
+            "yScale": 0.5
+        }
+    },
+    {
+        "usePrefab": "PlatformMiddle",
+        "transform": {
+            "xPos": 3.75,
+            "yPos": -4.25
+        }
+    },
+    {
+        "usePrefab": "PlatformMiddle",
+        "transform": {
+            "xPos": 3.25,
+            "yPos": -4.25
+        }
+    },
+    {
+        "usePrefab": "PlatformMiddle",
+        "transform": {
+            "xPos": 2.75,
+            "yPos": -4.25
+        }
+    },
+    {
+        "usePrefab": "PlatformMiddle",
+        "transform": {
+            "xPos": 2.25,
+            "yPos": -4.25
+        }
+    },
+    {
+        "usePrefab": "PlatformMiddle",
+        "transform": {
+            "xPos": 1.75,
+            "yPos": -4.25
+        }
+    },
+    {
+        "usePrefab": "PlatformLeftCorner",
+        "transform": {
+            "xPos": 1.25,
+            "yPos": -4.25
+        }
+    },
+    {
+        "usePrefab": "Collider",
+        "tag": "platform",
+        "transform": {
+            "xPos": 2.5,
+            "yPos": -4.25,
+            "xScale": 3,
+            "yScale": 0.5
+        }
+    },
+    {
+        "usePrefab": "Platform",
+        "transform": {
+            "xPos": -6.75,
+            "yPos": -4.75
+        }
+    },
+    {
+        "usePrefab": "Platform",
+        "transform": {
+            "xPos": -6.25,
+            "yPos": -4.75
+        }
+    },
+    {
+        "usePrefab": "Platform",
+        "transform": {
+            "xPos": -5.75,
+            "yPos": -4.75
+        }
+    },
+    {
+        "usePrefab": "Platform",
+        "transform": {
+            "xPos": -5.25,
+            "yPos": -4.75
+        }
+    },
+    {
+        "usePrefab": "Platform",
+        "transform": {
+            "xPos": -4.75,
+            "yPos": -4.75
+        }
+    },
+    {
+        "usePrefab": "Platform",
+        "transform": {
+            "xPos": -4.25,
+            "yPos": -4.75
+        }
+    },
+    {
+        "usePrefab": "Platform",
+        "transform": {
+            "xPos": -3.75,
+            "yPos": -4.75
+        }
+    },
+    {
+        "usePrefab": "Platform",
+        "transform": {
+            "xPos": -3.25,
+            "yPos": -4.75
+        }
+    },
+    {
+        "usePrefab": "Platform",
+        "transform": {
+            "xPos": -2.75,
+            "yPos": -4.75
+        }
+    },
+    {
+        "usePrefab": "Platform",
+        "transform": {
+            "xPos": -2.25,
+            "yPos": -4.75
+        }
+    },
+    {
+        "usePrefab": "Platform",
+        "transform": {
+            "xPos": -1.75,
+            "yPos": -4.75
+        }
+    },
+    {
+        "usePrefab": "WallRight",
+        "transform": {
+            "xPos": -1.25,
+            "yPos": -4.75
+        }
+    },
+    {
+        "usePrefab": "Collider",
+        "tag": "platform",
+        "transform": {
+            "xPos": -4,
+            "yPos": -4.75,
+            "xScale": 6,
+            "yScale": 0.5
+        }
+    },
+    {
+        "usePrefab": "Platform",
+        "transform": {
+            "xPos": 6.75,
+            "yPos": -4.75
+        }
+    },
+    {
+        "usePrefab": "Platform",
+        "transform": {
+            "xPos": 6.25,
+            "yPos": -4.75
+        }
+    },
+    {
+        "usePrefab": "Platform",
+        "transform": {
+            "xPos": 5.75,
+            "yPos": -4.75
+        }
+    },
+    {
+        "usePrefab": "Platform",
+        "transform": {
+            "xPos": 5.25,
+            "yPos": -4.75
+        }
+    },
+    {
+        "usePrefab": "Platform",
+        "transform": {
+            "xPos": 4.75,
+            "yPos": -4.75
+        }
+    },
+    {
+        "usePrefab": "Platform",
+        "transform": {
+            "xPos": 4.25,
+            "yPos": -4.75
+        }
+    },
+    {
+        "usePrefab": "Platform",
+        "transform": {
+            "xPos": 3.75,
+            "yPos": -4.75
+        }
+    },
+    {
+        "usePrefab": "Platform",
+        "transform": {
+            "xPos": 3.25,
+            "yPos": -4.75
+        }
+    },
+    {
+        "usePrefab": "Platform",
+        "transform": {
+            "xPos": 2.75,
+            "yPos": -4.75
+        }
+    },
+    {
+        "usePrefab": "Platform",
+        "transform": {
+            "xPos": 2.25,
+            "yPos": -4.75
+        }
+    },
+    {
+        "usePrefab": "Platform",
+        "transform": {
+            "xPos": 1.75,
+            "yPos": -4.75
+        }
+    },
+    {
+        "usePrefab": "WallLeft",
+        "transform": {
+            "xPos": 1.25,
+            "yPos": -4.75
+        }
+    },
+    {
+        "usePrefab": "Collider",
+        "tag": "platform",
+        "transform": {
+            "xPos": 4,
+            "yPos": -4.75,
+            "xScale": 6,
+            "yScale": 0.5
+        }
+    },
+    {
+        "usePrefab": "Fire",
+        "transform": {
+            "xPos": -0.5
+        }
+    },
+    {
+        "usePrefab": "FireSprites",
+        "transform": {
+            "xPos": -0.5
+        }
+    },
+    {
+        "usePrefab": "Fire",
+        "transform": {
+            "xPos": 0.5
+        }
+    },
+    {
+        "usePrefab": "FireSprites",
+        "transform": {
+            "xPos": 0.5
+        }
+    },
+    {
+        "usePrefab": "EnemySpawner",
+        "_comment": "enemy spawner top platform",
+        "transform": {
+            "yPos": 4.25
+        }
+    },
+    {
+        "usePrefab": "PlayerSpawner",
+        "_comment": "player spawner center stage",
+        "transform": {
+            "xPos": 0,
+            "yPos": 0
+        }
+    },
+    {
+        "usePrefab": "SpawnPoint",
+        "_comment": "Star Spawn Top Left",
+        "transform": {
+            "xPos": -4.75,
+            "yPos": 1.5
+        }
+    },
+    {
+        "usePrefab": "SpawnPoint",
+        "_comment": "Star Spawn Top Right",
+        "transform": {
+            "xPos": 4.75,
+            "yPos": 1.5
+        }
+    },
+    {
+        "usePrefab": "SpawnPoint",
+        "_comment": "Star Spawn Middle Left",
+        "transform": {
+            "xPos": -1.25,
+            "yPos": -0.5
+        }
+    },
+    {
+        "usePrefab": "SpawnPoint",
+        "_comment": "Star Spawn Middle Right",
+        "transform": {
+            "xPos": 1.25,
+            "yPos": -0.5
+        }
+    },
+    {
+        "usePrefab": "SpawnPoint",
+        "_comment": "Star Spawn Bottom Left",
+        "transform": {
+            "xPos": -5.25,
+            "yPos": -2.5
+        }
+    },
+    {
+        "usePrefab": "SpawnPoint",
+        "_comment": "Star Spawn Bottom Right",
+        "transform": {
+            "xPos": 5.25,
+            "yPos": -2.5
+        }
+    },
+    {
+        "usePrefab": "SpawnPoint",
+        "_comment": "Star Spawn Bottom Middle Left",
+        "transform": {
+            "xPos": -2.5,
+            "yPos": -3.5
+        }
+    },
+    {
+        "usePrefab": "SpawnPoint",
+        "_comment": "Star Spawn Bottom Middle Right",
+        "transform": {
+            "xPos": 2.5,
+            "yPos": -3.5
+        }
+    },
+    {
+        "usePrefab": "SpawnPoint",
+        "_comment": "Star Spawn Top Middle",
+        "transform": {
+            "xPos": 0,
+            "yPos": 3.5
+        }
+    }
+]


### PR DESCRIPTION
The game over scene is technically an overlay. You can trigger it by calling a function in `main.cpp` called `createGameOverOverlay()`. An example of it is located in `initialize()`. You can uncomment to see what it does.

For text alignment, we can now align text left, center or right. I also fixed a bug with the previous alignment where it wasn't exactly centered. I might fix the menu to make it look better once we have that in as well.